### PR TITLE
Some work on a new kokkos testing suite -- catching some bugs that I …

### DIFF
--- a/kitsune-tests/kokkos/Makefile
+++ b/kitsune-tests/kokkos/Makefile
@@ -1,0 +1,28 @@
+CLANGXX=$(KITSUNE_HOME)/bin/clang++
+OPT=$(KITSUNE_HOME)/bin/opt 
+
+KXXFLAGS=-fkokkos 
+CXXFLAGS=-std=c++14 -fPIC -I$(KITSUNE_HOME)/include 
+
+LDFLAGS= -L$(KITSUNE_HOME)/lib -lkokkos -ldl -lrt 
+
+types=kitsune kokkos
+sources=pfor_1d_sum 
+targets=$(foreach f,${sources}, $(foreach t, ${types}, ${f}_${t}))
+
+all: ${targets}
+
+%_kitsune: %.cpp
+	${CLANGXX} ${KXXFLAGS} ${CXXFLAGS} -S -emit-llvm -o $@.ll $<
+	@echo -n "ir line count: " && /usr/bin/wc -l $@.ll | cut -d ' ' -f1
+	${CLANGXX} ${KXXFLAGS} ${CXXFLAGS} -o $@ $< ${LDFLAGS}
+
+%_kokkos: %.cpp
+	${CLANGXX} ${CXXFLAGS} -S -emit-llvm -o $@.ll $< 
+	@echo -n "ir line count:" && /usr/bin/wc -l $@.ll | cut -d ' ' -f1 
+	${CLANGXX} ${CXXFLAGS} -o $@ $< ${LDFLAGS}
+
+clean:
+	rm -f ${targets} *.ll *~ 
+
+

--- a/kitsune-tests/kokkos/pfor_1d_sum.cpp
+++ b/kitsune-tests/kokkos/pfor_1d_sum.cpp
@@ -1,0 +1,90 @@
+/*
+ * ###########################################################################
+ * Copyright (c) 2019, Los Alamos National Security, LLC All rights
+ * reserved. Copyright 2019. Los Alamos National Security, LLC. This
+ * software was produced under U.S. Government contract DE-AC52-06NA25396
+ * for Los Alamos National Laboratory (LANL), which is operated by Los
+ * Alamos National Security, LLC for the U.S. Department of Energy. The
+ * U.S. Government has rights to use, reproduce, and distribute this
+ * software.  NEITHER THE GOVERNMENT NOR LOS ALAMOS NATIONAL SECURITY,
+ * LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY
+ * FOR THE USE OF THIS SOFTWARE.  If software is modified to produce
+ * derivative works, such modified software should be clearly marked, so
+ * as not to confuse it with the version available from LANL.
+ *  
+ * Additionally, redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following
+ * conditions are met: 1.       Redistributions of source code must
+ * retain the above copyright notice, this list of conditions and the
+ * following disclaimer. 2.      Redistributions in binary form must
+ * reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials
+ * provided with the distribution. 3.      Neither the name of Los Alamos
+ * National Security, LLC, Los Alamos National Laboratory, LANL, the U.S.
+ * Government, nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior
+ * written permission.
+  
+ * THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL LOS
+ * ALAMOS NATIONAL SECURITY, LLC OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE US
+ * ########################################################################### 
+ * 
+ * Notes
+ *
+ * ##### 
+ */
+#include <cstdio>
+#include <iostream>
+using namespace std;
+
+
+#include <Kokkos_Core.hpp>
+
+typedef Kokkos::View<double*> View;
+
+const size_t SIZE = 16;
+
+void initialize(View &v) {
+  Kokkos::parallel_for(SIZE, KOKKOS_LAMBDA(const int i) {
+    v(i) = double(i);
+  });
+}
+
+void dump(View &v) {
+  for(size_t i = 0; i < SIZE; ++i) { 
+    cout << "v(" << i << ") = " << v(i) << endl; 
+  }
+}
+
+int main (int argc, char* argv[]) {
+
+  Kokkos::initialize (argc, argv);
+
+  { // scope used for cleanup (to hush kokkos)... 
+    View a("a", SIZE);
+    View b("b", SIZE);
+    View c("c", SIZE);
+
+    initialize(a);
+    dump(a);
+    initialize(b);
+    dump(b);
+
+    Kokkos::parallel_for(SIZE, KOKKOS_LAMBDA (const int i) {
+      c(i) = a(i) + b(i);
+    });
+
+    dump(c); 
+  }
+
+  Kokkos::finalize ();
+}

--- a/llvm/include/llvm/Transforms/Tapir/CilkABI.h
+++ b/llvm/include/llvm/Transforms/Tapir/CilkABI.h
@@ -49,7 +49,9 @@ protected:
 
 class CilkABI : public TapirTarget {
 public:
-  CilkABI();
+  CilkABI() {};
+  ~CilkABI() {};
+
   Value *GetOrCreateWorker8(Function &F) override final;
   void createSync(SyncInst &inst, ValueToValueMapTy &DetachCtxToStackFrame)
     override final;

--- a/llvm/include/llvm/Transforms/Tapir/LoweringUtils.h
+++ b/llvm/include/llvm/Transforms/Tapir/LoweringUtils.h
@@ -42,7 +42,9 @@ Function *extractDetachBodyToFunction(DetachInst &Detach,
 
 class TapirTarget {
 public:
+  TapirTarget() {}; 
   virtual ~TapirTarget() {};
+
   //! For use in loopspawning grainsize calculation
   virtual Value *GetOrCreateWorker8(Function &F) = 0;
   virtual void createSync(SyncInst &inst,

--- a/llvm/include/llvm/Transforms/Tapir/OpenMPABI.h
+++ b/llvm/include/llvm/Transforms/Tapir/OpenMPABI.h
@@ -37,16 +37,19 @@ enum OpenMPSchedType {
 
 class OpenMPABI : public TapirTarget {
 public:
-OpenMPABI();
-Value *GetOrCreateWorker8(Function &F) override final;
-void createSync(SyncInst &inst, ValueToValueMapTy &DetachCtxToStackFrame) override final;
 
-Function *createDetach(DetachInst &Detach,
-                       ValueToValueMapTy &DetachCtxToStackFrame,
-                       DominatorTree &DT, AssumptionCache &AC) override final;
-void preProcessFunction(Function &F) override final;
-void postProcessFunction(Function &F) override final;
-void postProcessHelper(Function &F) override final;
+  OpenMPABI() {};
+  ~OpenMPABI() {};
+
+  Value *GetOrCreateWorker8(Function &F) override final;
+  void createSync(SyncInst &inst, ValueToValueMapTy &DetachCtxToStackFrame) override final;
+
+  Function *createDetach(DetachInst &Detach,
+			 ValueToValueMapTy &DetachCtxToStackFrame,
+			 DominatorTree &DT, AssumptionCache &AC) override final;
+  void preProcessFunction(Function &F) override final;
+  void postProcessFunction(Function &F) override final;
+  void postProcessHelper(Function &F) override final;
 };
 
 }  // end of llvm namespace

--- a/llvm/include/llvm/Transforms/Tapir/QthreadsABI.h
+++ b/llvm/include/llvm/Transforms/Tapir/QthreadsABI.h
@@ -21,8 +21,9 @@ namespace llvm {
 
 class QthreadsABI : public TapirTarget {
 public:
-  QthreadsABI();
-  virtual ~QthreadsABI(); 
+  QthreadsABI() {};
+  ~QthreadsABI() {};
+
   Value *GetOrCreateWorker8(Function &F) override final;
   void createSync(SyncInst &inst, ValueToValueMapTy &DetachCtxToStackFrame)
     override final;

--- a/llvm/lib/Transforms/Tapir/CilkABI.cpp
+++ b/llvm/lib/Transforms/Tapir/CilkABI.cpp
@@ -1377,8 +1377,6 @@ static bool makeFunctionDetachable(
   return true;
 }
 
-CilkABI::CilkABI() {}
-
 /// \brief Get/Create the worker count for the spawning function.
 Value *CilkABI::GetOrCreateWorker8(Function &F) {
   // Value* W8 = F.getValueSymbolTable()->lookup(worker8_name);

--- a/llvm/lib/Transforms/Tapir/OpenMPABI.cpp
+++ b/llvm/lib/Transforms/Tapir/OpenMPABI.cpp
@@ -347,8 +347,6 @@ Value *getOrCreateDefaultLocation(Module *M) {
 
 //##############################################################################
 
-llvm::OpenMPABI::OpenMPABI() {}
-
 /// \brief Get/Create the worker count for the spawning function.
 Value *llvm::OpenMPABI::GetOrCreateWorker8(Function &F) {
   /*

--- a/llvm/lib/Transforms/Tapir/QthreadsABI.cpp
+++ b/llvm/lib/Transforms/Tapir/QthreadsABI.cpp
@@ -72,9 +72,6 @@ DEFAULT_GET_QTHREAD_FUNC(qt_sinc_submit)
 DEFAULT_GET_QTHREAD_FUNC(qt_sinc_wait)
 DEFAULT_GET_QTHREAD_FUNC(qt_sinc_destroy)
 
-QthreadsABI::QthreadsABI() { }
-QthreadsABI::~QthreadsABI() { }
-
 static const StringRef worker8_name = "qthread_nworker8";
 
 /// \brief Get/Create the worker count for the spawning function. We stick it


### PR DESCRIPTION
…don't think we had previously caught.

Issue inbound...

Building with shared libraries has issues with Tapir transforms -- vtable entries are undefined w/ gcc 8.x,
which often suggests a missing virtual destructor.  After poking around and trying this the errors persist
for all Tapir-centric Transforms...  Need to revisit -- will open an issue for this too.